### PR TITLE
Enable codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Rebwon @JiwonDev @f-lab-bright


### PR DESCRIPTION
매번, Reviewers를 할당하는 것이 번거로워서 추가합니다.