### PR TITLE
Implement JWT Token Auth, Simple Account Domain 

### DIFF
--- a/account/build.gradle
+++ b/account/build.gradle
@@ -3,7 +3,14 @@ apply plugin: "io.spring.dependency-management"
 
 dependencies {
     api project(':common')
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/account/build.gradle
+++ b/account/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    implementation "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 bootJar {

--- a/account/src/main/java/kr/flab/movieon/account/application/AccountFacade.java
+++ b/account/src/main/java/kr/flab/movieon/account/application/AccountFacade.java
@@ -1,0 +1,44 @@
+package kr.flab.movieon.account.application;
+
+import kr.flab.movieon.account.domain.LoginAccountProcessor;
+import kr.flab.movieon.account.domain.RegisterAccountProcessor;
+import kr.flab.movieon.account.presentation.payload.JwtResponse;
+import kr.flab.movieon.account.presentation.payload.LoginAccountCommand;
+import kr.flab.movieon.account.presentation.payload.RegisterAccountCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AccountFacade {
+
+    private final LoginAccountProcessor loginAccountProcessor;
+    private final RegisterAccountProcessor registerAccountProcessor;
+
+    public AccountFacade(LoginAccountProcessor loginAccountProcessor,
+        RegisterAccountProcessor registerAccountProcessor) {
+        this.loginAccountProcessor = loginAccountProcessor;
+        this.registerAccountProcessor = registerAccountProcessor;
+    }
+
+    @Transactional(readOnly = true)
+    public JwtResponse login(LoginAccountCommand command) {
+        var accountDto = loginAccountProcessor.authenticate(command.getUsername(),
+            command.getPassword());
+        return JwtResponse.builder()
+            .token(accountDto.getAccessToken())
+            .username(accountDto.getUsername())
+            .email(accountDto.getEmail())
+            .roles(accountDto.getRoles())
+            .build();
+    }
+
+    @Transactional
+    public void register(RegisterAccountCommand command) {
+        registerAccountProcessor.register(
+            command.getUsername(),
+            command.getPassword(),
+            command.getEmail(),
+            command.getRole()
+        );
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/Account.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/Account.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -20,14 +19,12 @@ import javax.validation.constraints.Size;
 import kr.flab.movieon.common.EntityStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Getter
 @NoArgsConstructor
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "accounts",
     uniqueConstraints = {
         @UniqueConstraint(columnNames = "username"),
@@ -60,10 +57,10 @@ public class Account {
 
     private EntityStatus status = EntityStatus.ALIVE;
 
-    @CreatedDate
+    @CreationTimestamp
     private LocalDateTime createdDate;
 
-    @LastModifiedDate
+    @UpdateTimestamp
     private LocalDateTime modifiedDate;
 
     private Account(String username, String email, String password) {
@@ -76,10 +73,6 @@ public class Account {
 
     public static Account of(String username, String email, String password) {
         return new Account(username, email, password);
-    }
-
-    void setId(Long id) {
-        this.id = id;
     }
 
     public void changeRoles(Set<Role> roles) {

--- a/account/src/main/java/kr/flab/movieon/account/domain/Account.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/Account.java
@@ -1,6 +1,88 @@
 package kr.flab.movieon.account.domain;
 
-public final class Account {
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import kr.flab.movieon.common.EntityStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-    // TODO 계정 도메인
+@Getter
+@NoArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "accounts",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = "username"),
+        @UniqueConstraint(columnNames = "email")
+    })
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 20)
+    private String username;
+
+    @NotBlank
+    @Size(max = 50)
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(max = 120)
+    private String password;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "account_roles",
+        joinColumns = @JoinColumn(name = "account_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Set<Role> roles = new HashSet<>();
+
+    private EntityStatus status = EntityStatus.ALIVE;
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+    private Account(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = LocalDateTime.now();
+    }
+
+    public static Account of(String username, String email, String password) {
+        return new Account(username, email, password);
+    }
+
+    void setId(Long id) {
+        this.id = id;
+    }
+
+    public void changeRoles(Set<Role> roles) {
+        this.roles = Set.copyOf(roles);
+    }
 }

--- a/account/src/main/java/kr/flab/movieon/account/domain/AccountDto.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/AccountDto.java
@@ -1,0 +1,16 @@
+package kr.flab.movieon.account.domain;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public final class AccountDto {
+
+    private String accessToken;
+    private Long id;
+    private String username;
+    private String email;
+    private List<String> roles;
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/AccountRepository.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/AccountRepository.java
@@ -1,0 +1,17 @@
+package kr.flab.movieon.account.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Optional<Account> findByUsername(String username);
+
+    Optional<Account> findByEmail(String email);
+
+    Boolean existsByUsername(String username);
+
+    Boolean existsByEmail(String email);
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/LoginAccountProcessor.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/LoginAccountProcessor.java
@@ -1,0 +1,6 @@
+package kr.flab.movieon.account.domain;
+
+public interface LoginAccountProcessor {
+
+    AccountDto authenticate(String username, String password);
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/RegisterAccountProcessor.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/RegisterAccountProcessor.java
@@ -1,0 +1,8 @@
+package kr.flab.movieon.account.domain;
+
+import java.util.List;
+
+public interface RegisterAccountProcessor {
+
+    void register(String username, String password, String email, List<String> roles);
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/Role.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/Role.java
@@ -1,0 +1,35 @@
+package kr.flab.movieon.account.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private RoleType name;
+
+    public Role(RoleType name) {
+        this.name = name;
+    }
+
+    void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/RoleRepository.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/RoleRepository.java
@@ -1,0 +1,11 @@
+package kr.flab.movieon.account.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+    Optional<Role> findByName(RoleType name);
+}

--- a/account/src/main/java/kr/flab/movieon/account/domain/RoleType.java
+++ b/account/src/main/java/kr/flab/movieon/account/domain/RoleType.java
@@ -1,0 +1,6 @@
+package kr.flab.movieon.account.domain;
+
+public enum RoleType {
+    USER,
+    ADMIN
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/LoginAccountProcessorImpl.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/LoginAccountProcessorImpl.java
@@ -1,0 +1,49 @@
+package kr.flab.movieon.account.infrastructure;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.flab.movieon.account.domain.AccountDto;
+import kr.flab.movieon.account.domain.LoginAccountProcessor;
+import kr.flab.movieon.account.infrastructure.security.TokenUtils;
+import kr.flab.movieon.account.infrastructure.security.domain.AccountDetails;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class LoginAccountProcessorImpl implements LoginAccountProcessor {
+
+    private final AuthenticationManager authenticationManager;
+    private final TokenUtils tokenUtils;
+
+    public LoginAccountProcessorImpl(
+        AuthenticationManager authenticationManager,
+        TokenUtils tokenUtils) {
+        this.authenticationManager = authenticationManager;
+        this.tokenUtils = tokenUtils;
+    }
+
+    @Override
+    public AccountDto authenticate(String username, String password) {
+        Authentication authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(username, password)
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String generatedToken = tokenUtils.generateJwtToken(authentication);
+
+        AccountDetails accountDetails = (AccountDetails) authentication.getPrincipal();
+        List<String> roles = accountDetails.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.toList());
+
+        return AccountDto.builder()
+            .accessToken(generatedToken)
+            .id(accountDetails.getId())
+            .email(accountDetails.getEmail())
+            .username(accountDetails.getUsername())
+            .roles(roles)
+            .build();
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/RegisterAccountProcessorImpl.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/RegisterAccountProcessorImpl.java
@@ -1,0 +1,62 @@
+package kr.flab.movieon.account.infrastructure;
+
+import static java.lang.Boolean.TRUE;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import kr.flab.movieon.account.domain.Account;
+import kr.flab.movieon.account.domain.AccountRepository;
+import kr.flab.movieon.account.domain.RegisterAccountProcessor;
+import kr.flab.movieon.account.domain.Role;
+import kr.flab.movieon.account.domain.RoleRepository;
+import kr.flab.movieon.account.domain.RoleType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public final class RegisterAccountProcessorImpl implements RegisterAccountProcessor {
+
+    private final AccountRepository accountRepository;
+
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder encoder;
+
+    public RegisterAccountProcessorImpl(
+        AccountRepository accountRepository,
+        RoleRepository roleRepository,
+        PasswordEncoder encoder) {
+        this.accountRepository = accountRepository;
+        this.roleRepository = roleRepository;
+        this.encoder = encoder;
+    }
+
+    @Override
+    public void register(String username, String password, String email,
+        List<String> roles) {
+        if (TRUE.equals(accountRepository.existsByUsername(username))) {
+            throw new IllegalArgumentException("Error: Username is already in use");
+        }
+
+        if (TRUE.equals(accountRepository.existsByEmail(email))) {
+            throw new IllegalArgumentException("Error: Email is already in use");
+        }
+
+        Set<Role> newRoles = new HashSet<>();
+
+        roles.forEach(role -> {
+            if (role.equalsIgnoreCase(RoleType.ADMIN.name())) {
+                newRoles.add(findByRoleType(RoleType.ADMIN));
+            } else {
+                newRoles.add(findByRoleType(RoleType.USER));
+            }
+        });
+
+        var account = Account.of(username, email, encoder.encode(password));
+        account.changeRoles(newRoles);
+        accountRepository.save(account);
+    }
+
+    private Role findByRoleType(RoleType name) {
+        return roleRepository.findByName(name)
+            .orElseThrow(() -> new IllegalArgumentException("Error: Role is not found. : " + name));
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/config/AccountModuleConfig.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/config/AccountModuleConfig.java
@@ -1,0 +1,30 @@
+package kr.flab.movieon.account.infrastructure.config;
+
+import kr.flab.movieon.account.domain.AccountRepository;
+import kr.flab.movieon.account.domain.LoginAccountProcessor;
+import kr.flab.movieon.account.domain.RegisterAccountProcessor;
+import kr.flab.movieon.account.domain.RoleRepository;
+import kr.flab.movieon.account.infrastructure.LoginAccountProcessorImpl;
+import kr.flab.movieon.account.infrastructure.RegisterAccountProcessorImpl;
+import kr.flab.movieon.account.infrastructure.security.TokenUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AccountModuleConfig {
+
+    @Bean
+    public LoginAccountProcessor loginAccountProcessor(
+        AuthenticationManager authenticationManager, TokenUtils tokenUtils) {
+        return new LoginAccountProcessorImpl(authenticationManager, tokenUtils);
+    }
+
+    @Bean
+    public RegisterAccountProcessor registerAccountProcessor(
+        AccountRepository accountRepository, RoleRepository roleRepository,
+        PasswordEncoder passwordEncoder) {
+        return new RegisterAccountProcessorImpl(accountRepository, roleRepository, passwordEncoder);
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/config/SecurityConfig.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,103 @@
+package kr.flab.movieon.account.infrastructure.config;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.POST;
+
+import kr.flab.movieon.account.infrastructure.security.JwtTokenAuthFilter;
+import kr.flab.movieon.account.infrastructure.security.TokenAccessDeniedHandler;
+import kr.flab.movieon.account.infrastructure.security.TokenAuthEntryPoint;
+import kr.flab.movieon.account.infrastructure.security.TokenUtils;
+import kr.flab.movieon.account.infrastructure.security.domain.AccountDetailsService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final AccountDetailsService accountDetailsService;
+    private final TokenUtils tokenUtils;
+
+    public SecurityConfig(
+        AccountDetailsService accountDetailsService,
+        TokenUtils tokenUtils) {
+        this.accountDetailsService = accountDetailsService;
+        this.tokenUtils = tokenUtils;
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder authenticationManagerBuilder)
+        throws Exception {
+        authenticationManagerBuilder.userDetailsService(accountDetailsService)
+            .passwordEncoder(passwordEncoder());
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors()
+
+            .and()
+            .csrf().disable()
+            .httpBasic().disable()
+            .formLogin().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+            .and()
+            .authorizeRequests()
+            .antMatchers(OPTIONS).permitAll()
+            .antMatchers(POST, "/api/auth/**").permitAll()
+            .antMatchers(GET, "/api/test/**").permitAll()
+            .anyRequest().authenticated()
+
+            .and()
+            .exceptionHandling()
+            .accessDeniedHandler(jwtAccessDeniedHandler())
+            .authenticationEntryPoint(jwtAuthEntryPoint())
+
+            .and()
+            .addFilterBefore(jwtTokenAuthFilter(accountDetailsService),
+                UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Bean
+    public JwtTokenAuthFilter jwtTokenAuthFilter(AccountDetailsService accountDetailsService) {
+        return new JwtTokenAuthFilter(
+            tokenUtils,
+            accountDetailsService
+        );
+    }
+
+    @Bean
+    public TokenAccessDeniedHandler jwtAccessDeniedHandler() {
+        return new TokenAccessDeniedHandler();
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        //AuthenticationManager 를 외부에서 사용하기 위하여 @Bean 등록.
+        return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public TokenAuthEntryPoint jwtAuthEntryPoint() {
+        return new TokenAuthEntryPoint();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/JwtTokenAuthFilter.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/JwtTokenAuthFilter.java
@@ -1,0 +1,61 @@
+package kr.flab.movieon.account.infrastructure.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import kr.flab.movieon.account.infrastructure.security.domain.AccountDetailsService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+public class JwtTokenAuthFilter extends OncePerRequestFilter {
+
+    private final TokenUtils tokenUtils;
+    private final AccountDetailsService accountDetailsService;
+
+    public JwtTokenAuthFilter(TokenUtils tokenUtils,
+        AccountDetailsService accountDetailsService) {
+        this.tokenUtils = tokenUtils;
+        this.accountDetailsService = accountDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String jwt = parseToken(request);
+        if (jwt == null || !tokenUtils.validateJwtToken(jwt)) {
+            filterChain.doFilter(request, response);
+        }
+
+        var accountDetails = accountDetailsService.loadUserByUsername(
+            tokenUtils.getUserNameFromJwtToken(jwt));
+
+        var authentication = new UsernamePasswordAuthenticationToken(
+            accountDetails, null, accountDetails.getAuthorities());
+
+        authentication.setDetails(
+            new WebAuthenticationDetailsSource().buildDetails(request));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String parseToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/JwtTokenAuthFilter.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/JwtTokenAuthFilter.java
@@ -32,6 +32,7 @@ public class JwtTokenAuthFilter extends OncePerRequestFilter {
         String jwt = parseToken(request);
         if (jwt == null || !tokenUtils.validateJwtToken(jwt)) {
             filterChain.doFilter(request, response);
+            return;
         }
 
         var accountDetails = accountDetailsService.loadUserByUsername(

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/SkipPathRequestMatcher.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/SkipPathRequestMatcher.java
@@ -1,0 +1,36 @@
+package kr.flab.movieon.account.infrastructure.security;
+
+import io.jsonwebtoken.lang.Assert;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+@Slf4j
+public class SkipPathRequestMatcher implements RequestMatcher {
+
+    private final OrRequestMatcher matcher;
+    private final RequestMatcher processingMatcher;
+
+    public SkipPathRequestMatcher(List<String> skipUrls, String processingPath) {
+        Assert.notNull(skipUrls);
+        List<RequestMatcher> matchers = skipUrls.stream()
+            .map(AntPathRequestMatcher::new)
+            .collect(Collectors.toList());
+
+        matcher = new OrRequestMatcher(matchers);
+        processingMatcher = new AntPathRequestMatcher(processingPath);
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest httpServletRequest) {
+        if (matcher.matches(httpServletRequest)) {
+            return false;
+        }
+        return processingMatcher.matches(httpServletRequest);
+    }
+}
+

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenAccessDeniedHandler.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package kr.flab.movieon.account.infrastructure.security;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+@Slf4j
+public class TokenAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException {
+
+        log.error("Access Denied : {}", accessDeniedException.getMessage());
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Error: Access Denied");
+
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenAuthEntryPoint.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenAuthEntryPoint.java
@@ -1,0 +1,21 @@
+package kr.flab.movieon.account.infrastructure.security;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@Slf4j
+public class TokenAuthEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+
+        log.error("Unauthorized error: {}", authException.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Error: Unauthorized");
+    }
+
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenUtils.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenUtils.java
@@ -18,15 +18,14 @@ import org.springframework.stereotype.Component;
 @Component
 public final class TokenUtils {
 
-    private final String base64Secret;
+    private final byte[] base64Secret;
     private final long tokenValidityInMilliseconds;
 
     public TokenUtils(
-        // #TODO application.yml의 profile값을 불러오는데 실패해서, 일단 임시로 기본값 사용.
-        @Value("${jwt.base64-secret:c2VjcmV0S2V5LXRlc3QtYXV0aG9yaXphdGlvbi1qd3QtbWFuYWdlLXRva2Vu}")
+        @Value("${jwt.base64-secret}")
             String base64Secret,
-        @Value("${jwt.token-validity-in-seconds:86400}") long tokenValidityInSeconds) {
-        this.base64Secret = base64Secret;
+        @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds) {
+        this.base64Secret = base64Secret.getBytes(StandardCharsets.UTF_8);
         this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
     }
 
@@ -37,7 +36,7 @@ public final class TokenUtils {
             .setSubject(accountPrincipal.getUsername())
             .setIssuedAt(new Date())
             .setExpiration(new Date((new Date()).getTime() + tokenValidityInMilliseconds))
-            .signWith(Keys.hmacShaKeyFor(base64Secret.getBytes(StandardCharsets.UTF_8)),
+            .signWith(Keys.hmacShaKeyFor(base64Secret),
                 SignatureAlgorithm.HS256)
             .compact();
     }

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenUtils.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/TokenUtils.java
@@ -1,0 +1,69 @@
+package kr.flab.movieon.account.infrastructure.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import kr.flab.movieon.account.infrastructure.security.domain.AccountDetails;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public final class TokenUtils {
+
+    private final String base64Secret;
+    private final long tokenValidityInMilliseconds;
+
+    public TokenUtils(
+        // #TODO application.yml의 profile값을 불러오는데 실패해서, 일단 임시로 기본값 사용.
+        @Value("${jwt.base64-secret:c2VjcmV0S2V5LXRlc3QtYXV0aG9yaXphdGlvbi1qd3QtbWFuYWdlLXRva2Vu}")
+            String base64Secret,
+        @Value("${jwt.token-validity-in-seconds:86400}") long tokenValidityInSeconds) {
+        this.base64Secret = base64Secret;
+        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+    }
+
+    public String generateJwtToken(Authentication authentication) {
+        AccountDetails accountPrincipal = (AccountDetails) authentication.getPrincipal();
+
+        return Jwts.builder()
+            .setSubject(accountPrincipal.getUsername())
+            .setIssuedAt(new Date())
+            .setExpiration(new Date((new Date()).getTime() + tokenValidityInMilliseconds))
+            .signWith(Keys.hmacShaKeyFor(base64Secret.getBytes(StandardCharsets.UTF_8)),
+                SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String getUserNameFromJwtToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(base64Secret).build().parseClaimsJws(token)
+            .getBody()
+            .getSubject();
+    }
+
+    public boolean validateJwtToken(String authToken) {
+        try {
+            Jwts.parserBuilder().setSigningKey(base64Secret).build().parseClaimsJws(authToken);
+            return true;
+        } catch (SecurityException e) {
+            log.info("Invalid JWT signature: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("JWT token is expired: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("JWT token is unsupported: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty: {}", e.getMessage());
+        }
+
+        return false;
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/domain/AccountDetails.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/domain/AccountDetails.java
@@ -1,0 +1,101 @@
+package kr.flab.movieon.account.infrastructure.security.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import kr.flab.movieon.account.domain.Account;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class AccountDetails implements UserDetails {
+
+    private final Long id;
+
+    private final String username;
+
+    private final String email;
+
+    @JsonIgnore
+    private final String password;
+
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    private AccountDetails(Long id, String username, String email, String password,
+        Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public static UserDetails from(Account account) {
+        List<GrantedAuthority> authorities = account.getRoles().stream()
+            .map(role -> new SimpleGrantedAuthority(role.getName().name()))
+            .collect(Collectors.toList());
+
+        return new AccountDetails(
+            account.getId(),
+            account.getUsername(),
+            account.getEmail(),
+            account.getPassword(),
+            authorities);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AccountDetails that = (AccountDetails) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/infrastructure/security/domain/AccountDetailsService.java
+++ b/account/src/main/java/kr/flab/movieon/account/infrastructure/security/domain/AccountDetailsService.java
@@ -1,0 +1,28 @@
+package kr.flab.movieon.account.infrastructure.security.domain;
+
+import kr.flab.movieon.account.domain.AccountRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AccountDetailsService implements UserDetailsService {
+
+    private final AccountRepository accountRepository;
+
+    public AccountDetailsService(
+        AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        var account = accountRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("Account not found with username: "
+                + username));
+        return AccountDetails.from(account);
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/presentation/TestController.java
+++ b/account/src/main/java/kr/flab/movieon/account/presentation/TestController.java
@@ -1,0 +1,27 @@
+package kr.flab.movieon.account.presentation;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping(path = "/api/test",
+    produces = MediaType.APPLICATION_JSON_VALUE,
+    consumes = MediaType.APPLICATION_JSON_VALUE)
+public class TestController {
+
+    @GetMapping("/all")
+    public String allAccess() {
+        return "Public Access";
+    }
+
+    @GetMapping("/admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    public String adminAccess() {
+        return "Admin Access";
+    }
+}

--- a/account/src/main/java/kr/flab/movieon/account/presentation/TokenAuthController.java
+++ b/account/src/main/java/kr/flab/movieon/account/presentation/TokenAuthController.java
@@ -1,0 +1,45 @@
+package kr.flab.movieon.account.presentation;
+
+import javax.validation.Valid;
+import kr.flab.movieon.account.application.AccountFacade;
+import kr.flab.movieon.account.presentation.payload.JwtResponse;
+import kr.flab.movieon.account.presentation.payload.LoginAccountCommand;
+import kr.flab.movieon.account.presentation.payload.RegisterAccountCommand;
+import kr.flab.movieon.common.ApiResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping(path = "/api/auth",
+    produces = MediaType.APPLICATION_JSON_VALUE,
+    consumes = MediaType.APPLICATION_JSON_VALUE)
+public class TokenAuthController {
+
+    private final AccountFacade accountFacade;
+
+    public TokenAuthController(AccountFacade accountFacade) {
+        this.accountFacade = accountFacade;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> register(
+        @Valid @RequestBody RegisterAccountCommand request) {
+        accountFacade.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResult<JwtResponse>> authenticate(
+        @Valid @RequestBody LoginAccountCommand request) {
+        return ResponseEntity.ok(
+            ApiResult.success(accountFacade.login(request)));
+    }
+
+}

--- a/account/src/main/java/kr/flab/movieon/account/presentation/payload/JwtResponse.java
+++ b/account/src/main/java/kr/flab/movieon/account/presentation/payload/JwtResponse.java
@@ -1,0 +1,17 @@
+package kr.flab.movieon.account.presentation.payload;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class JwtResponse {
+
+    @Builder.Default
+    private String type = "Bearer";
+    private String token;
+    private String username;
+    private String email;
+    private List<String> roles;
+}

--- a/account/src/main/java/kr/flab/movieon/account/presentation/payload/LoginAccountCommand.java
+++ b/account/src/main/java/kr/flab/movieon/account/presentation/payload/LoginAccountCommand.java
@@ -1,0 +1,14 @@
+package kr.flab.movieon.account.presentation.payload;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginAccountCommand {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+}

--- a/account/src/main/java/kr/flab/movieon/account/presentation/payload/RegisterAccountCommand.java
+++ b/account/src/main/java/kr/flab/movieon/account/presentation/payload/RegisterAccountCommand.java
@@ -1,0 +1,28 @@
+package kr.flab.movieon.account.presentation.payload;
+
+import java.util.List;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class RegisterAccountCommand {
+
+    @NotBlank
+    @Size(min = 3, max = 20)
+    private String username;
+
+    @NotBlank
+    @Size(max = 50)
+    @Email
+    private String email;
+
+    @NotNull
+    private List<String> role;
+
+    @NotBlank
+    @Size(min = 6, max = 40)
+    private String password;
+}

--- a/account/src/main/resources/application.yml
+++ b/account/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+jwt:
+  header: Authorization
+  secret: "secretKey-test-authorization-jwt-manage-token"
+  base64-secret: c2VjcmV0S2V5LXRlc3QtYXV0aG9yaXphdGlvbi1qd3QtbWFuYWdlLXRva2Vu
+  # 24 hours
+  token-validity-in-seconds: 86400

--- a/account/src/main/resources/application.yml
+++ b/account/src/main/resources/application.yml
@@ -1,6 +1,0 @@
-jwt:
-  header: Authorization
-  secret: "secretKey-test-authorization-jwt-manage-token"
-  base64-secret: c2VjcmV0S2V5LXRlc3QtYXV0aG9yaXphdGlvbi1qd3QtbWFuYWdlLXRva2Vu
-  # 24 hours
-  token-validity-in-seconds: 86400

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -2,3 +2,9 @@ spring:
   h2:
     console:
       enabled: true
+jwt:
+  header: Authorization
+  secret: "secretKey-test-authorization-jwt-manage-token"
+  base64-secret: c2VjcmV0S2V5LXRlc3QtYXV0aG9yaXphdGlvbi1qd3QtbWFuYWdlLXRva2Vu
+  # 24 hours
+  token-validity-in-seconds: 86400

--- a/common/src/main/java/kr/flab/movieon/common/ApiResult.java
+++ b/common/src/main/java/kr/flab/movieon/common/ApiResult.java
@@ -1,0 +1,24 @@
+package kr.flab.movieon.common;
+
+import lombok.Getter;
+
+@Getter
+public final class ApiResult<T> {
+    private final boolean success;
+    private final T data;
+    private final String message;
+
+    private ApiResult(boolean success, T data, String message) {
+        this.success = success;
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> ApiResult<T> success(T data) {
+        return new ApiResult<>(true, data, null);
+    }
+
+    public static ApiResult<?> error(String message) {
+        return new ApiResult<>(false, null, message);
+    }
+}

--- a/common/src/main/java/kr/flab/movieon/common/EntityStatus.java
+++ b/common/src/main/java/kr/flab/movieon/common/EntityStatus.java
@@ -1,0 +1,5 @@
+package kr.flab.movieon.common;
+
+public enum EntityStatus {
+    ALIVE, DELETED
+}


### PR DESCRIPTION
📑Implement Account Domain, Account Authentication
- Spring Security 를 사용한 JWT 토큰 인증
- JwtUtils 객체에 사용한 spring profile 이 적용되지 않아서, 임시로 값을 직접 할당했습니다.
- 프로젝트 종속성 추가 (jpa,security,validation,jjwt)

📑Implement Auth HTTP API
테스트 용도로 간단한 인증 API(login, singup) 구현했습니다.
 
