### PR TITLE
Fix flyway dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "it.ozimov:embedded-redis:0.7.2"
     testImplementation "it.ozimov:embedded-redis:0.7.2"
     implementation "mysql:mysql-connector-java"
-    implementation "org.flywaydb:flyway-core"
+    implementation "org.flywaydb:flyway-mysql"
     testImplementation "com.h2database:h2"
     testImplementation "com.navercorp.fixturemonkey:fixture-monkey-starter:0.3.5"
     testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -41,7 +41,6 @@ server:
 app:
   url: 'http://localhost:${server.port}'
 
-
 logging:
   level:
     kr.flab.movieon: debug


### PR DESCRIPTION
https://stackoverflow.com/questions/70923478/flywayexception-unsupported-database-mariadb-10-5

flyway 8.2.1 부터 MySQL과 MariaDB는 flyway-core가 아니라 flyway-mysql을 넣어주어야만 동작하도록 변경됨.

flyway-mysql을 넣으면 core도 같이 들어감.